### PR TITLE
Minor improvements

### DIFF
--- a/notarize.js
+++ b/notarize.js
@@ -334,21 +334,36 @@ const createNewRevision = async (
   let verificationData = {
     previous_verification_hash: previousVerificationHash,
     nonce: prepareNonce(),
-    //domain_id: getDomainName(), // TODO
     local_timestamp: timestamp,
     revision_type,
   }
 
   switch (revision_type) {
     case "content":
-      const fileContent = fs.readFileSync(filename, "utf8")
-      verificationData["content"] = fileContent
-      break
-    case "file_hash":
-      const fileHash = main.getFileHashSum(filename)
-      verificationData["file_hash"] = fileHash
-      aquaObject.file_index[fileHash] = filename
-      break
+    case "file_hash": // Both content and file_hash revisions include file hashes
+      const fileHash = revision_type === "content" 
+        ? main.getFileHashSumFromContent(fs.readFileSync(filename, "utf8")) 
+        : main.getFileHashSum(filename);
+
+      // Check if this file hash already exists in any revision
+      const existingRevision = Object.values(aquaObject.revisions).find(revision => 
+        (revision.file_hash && revision.file_hash === fileHash) || 
+        (revision.content && main.getFileHashSumFromContent(revision.content) === fileHash)
+      );
+
+      if (existingRevision) {
+        console.log(`Abort. No new revision created.\n \nA new content revision is obsolete as a content revision with the same file hash (${fileHash}) already exists. `);
+        process.exit(1); // Exit with a non-zero status code to indicate an error
+      }
+
+      if (revision_type === "content") {
+        verificationData["content"] = fs.readFileSync(filename, "utf8");
+      } else {
+        verificationData["file_hash"] = fileHash;
+        aquaObject.file_index[fileHash] = filename;
+      }
+      break;
+
     case "signature":
       const sigData = await prepareSignature(previousVerificationHash)
       verificationData = { ...verificationData, ...sigData }
@@ -426,11 +441,32 @@ const createNewRevision = async (
     const verificationHashes = Object.keys(revisions)
     const lastRevisionHash = verificationHashes[verificationHashes.length - 1]
 
+    /*
     if (enableRemoveRevision) {
       delete aquaObject.revisions[lastRevisionHash]
       serializeAquaObject(metadataFilename, aquaObject)
       console.log(`Most recent revision ${lastRevisionHash} has been removed`)
       return
+    }
+    */
+
+    if (enableRemoveRevision) {
+      delete aquaObject.revisions[lastRevisionHash]
+      console.log(`Most recent revision ${lastRevisionHash} has been removed`)
+      if (Object.keys(aquaObject.revisions).length === 0) {
+        // If there are no revisions left, delete the .aqua.json file
+        try {
+          fs.unlinkSync(metadataFilename)
+          console.log(`${metadataFilename} has been deleted because there are no revisions left.`)
+          // Since we've deleted the file, there's no need to return here; the script should end.
+        } catch (err) {
+          console.error(`Failed to delete ${metadataFilename}:`, err)
+        }
+      } else {
+        serializeAquaObject(metadataFilename, aquaObject)
+        console.log(`Most recent revision ${lastRevisionHash} has been removed`)
+      }
+      return // This return ensures the function stops here, regardless of whether we deleted the file or not.
     }
 
     if (enableSignature && enableWitness) {

--- a/notarize.js
+++ b/notarize.js
@@ -441,16 +441,7 @@ const createNewRevision = async (
     const verificationHashes = Object.keys(revisions)
     const lastRevisionHash = verificationHashes[verificationHashes.length - 1]
 
-    /*
-    if (enableRemoveRevision) {
-      delete aquaObject.revisions[lastRevisionHash]
-      serializeAquaObject(metadataFilename, aquaObject)
-      console.log(`Most recent revision ${lastRevisionHash} has been removed`)
-      return
-    }
-    */
-
-    if (enableRemoveRevision) {
+      if (enableRemoveRevision) {
       delete aquaObject.revisions[lastRevisionHash]
       console.log(`Most recent revision ${lastRevisionHash} has been removed`)
       if (Object.keys(aquaObject.revisions).length === 0) {
@@ -485,7 +476,6 @@ const createNewRevision = async (
       revisionType = "content"
     }
 
-    
     const verificationData = await createNewRevision(
       lastRevisionHash,
       timestamp,


### PR DESCRIPTION
Two little improvements for the aqua-verifier-js:

1) Check if a content revision with the same file-hash already exists in that chain, if this is the case, don't add a second one.
2) Check if the last revision was removed with the --remove flag. If this was the case, delete the aqua.json file.

